### PR TITLE
fix it with one line

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -421,7 +421,7 @@ class RedisCluster(Redis):
                 raise
             except (ConnectionError, TimeoutError):
                 try_random_node = True
-
+                self.refresh_table_asap = True
                 if ttl < self.RedisClusterRequestTTL / 2:
                     time.sleep(0.1)
             except ClusterDownError as e:


### PR DESCRIPTION
fix this problem:
- if the rediscluster's topology get refreshed, the client should refresh the node's information to sent execution
